### PR TITLE
Add enable cast option

### DIFF
--- a/lib/redshift_connector/queuery_data_source.rb
+++ b/lib/redshift_connector/queuery_data_source.rb
@@ -13,8 +13,8 @@ module RedshiftConnector
       ExporterBuilder.new(ds: self, exporter_class: QueueryExporter)
     end
 
-    def execute_query(stmt, params = [])
-      @client.query(stmt, params)
+    def execute_query(stmt, params = [], enable_cast: false)
+      @client.query(stmt, params, enable_cast: enable_cast)
     rescue QueueryClient::QueryError => ex
       raise ExportError, ex.message
     end

--- a/lib/redshift_connector/queuery_direct_data_source.rb
+++ b/lib/redshift_connector/queuery_direct_data_source.rb
@@ -3,8 +3,8 @@ require 'redshift_connector/exception'
 
 module RedshiftConnector
   class QueueryDirectDataSource < QueueryDataSource
-    def execute_query(stmt, params = [])
-      super(stmt, params).direct
+    def execute_query(stmt, params = [], enable_cast: false)
+      super(stmt, params, enable_cast).direct
     end
   end
 end

--- a/lib/redshift_connector/queuery_direct_data_source.rb
+++ b/lib/redshift_connector/queuery_direct_data_source.rb
@@ -4,7 +4,7 @@ require 'redshift_connector/exception'
 module RedshiftConnector
   class QueueryDirectDataSource < QueueryDataSource
     def execute_query(stmt, params = [], enable_cast: false)
-      super(stmt, params, enable_cast).direct
+      super(stmt, params, enable_cast: enable_cast).direct
     end
   end
 end

--- a/lib/redshift_connector/queuery_exporter.rb
+++ b/lib/redshift_connector/queuery_exporter.rb
@@ -2,12 +2,14 @@ require 'redshift_connector/logger'
 
 module RedshiftConnector
   class QueueryExporter
-    def initialize(ds:, query:, bundle_params: nil, enable_sort: false, logger: RedshiftConnector.logger)
+    def initialize(ds:, query:, query_params: [], bundle_params: nil, enable_sort: false, enable_cast: false, logger: RedshiftConnector.logger)
       @ds = ds
       @query = query
+      @query_params = query_params
       @bundle_params = bundle_params
       @bundle = nil
       @enable_sort = enable_sort
+      @enable_cast = enable_cast
       @logger = logger
     end
 
@@ -22,7 +24,7 @@ module RedshiftConnector
       @logger.info "[SQL/Queuery] #{stmt.strip}"
       # FIXME: support enable_sort
       # FIXME: pass bundle_params?
-      @bundle = @ds.execute_query(stmt)
+      @bundle = @ds.execute_query(stmt, @query_params, enable_cast: @enable_cast)
       @bundle
     end
   end

--- a/redshift_connector-queuery.gemspec
+++ b/redshift_connector-queuery.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.1.0'
-  s.add_dependency 'redshift_connector', '~> 8.0'
-  s.add_dependency 'queuery_client', '~> 1.0'
+  s.add_dependency 'redshift_connector', '~> 8.1'
+  s.add_dependency 'queuery_client', '~> 1.1'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'rake'
 end

--- a/test/config.rb
+++ b/test/config.rb
@@ -3,7 +3,7 @@ GarageClient.configure do |config|
 end
 
 QueueryClient.configure do |config|
-  config.endpoint = ENV['QUEUERY_HOST']
+  config.endpoint = ENV['QUEUERY_ENDPOINT']
   config.token = ENV['QUEUERY_TOKEN']
   config.token_secret = ENV['QUEUERY_TOKEN_SECRET']
 end


### PR DESCRIPTION
関連 https://github.com/bricolages/queuery_client/pull/7

RedshiftのUnloadで使えるMANIFESTオプションを有効にできるようにします。手元でテストも通りました。
https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_UNLOAD.html

queuery_clientを内部で使っているのでこちらではパラメータを追加しただけです。デフォルトはfalseです。
型情報に基づいて実際にキャストする部分は redshift_connector の方で行っているのでそちらにも[PRを出しました](https://github.com/bricolages/redshift_connector/pull/21)。

```ruby
[1] pry(main)> # setup省略
[2] pry(main)> array1 = []
RedshiftConnector.foreach(schema: 'example', table: 'items', query: 'select id from example.items where id < 20') {|r| array1 << r}
array2 = []
RedshiftConnector.foreach(schema: 'example', table: 'items', query: 'select id from example.items where id < 20', enable_cast: true) {|r| array2 << r}
[3] pry(main)> array1
=> [["1"], ["14"], ["19"], ["18"], ["12"], ["17"], ["13"]]
[4] pry(main)> array2
=> [[1], [14], [19], [18], [12], [17], [13]]
```
