### PR TITLE
Add type cast option test for transport methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org/'
 gemspec
 gem 'activerecord', '~> 5.0'
 gem 'mysql2', '< 0.5.0'
+gem 'rails'
+gem 'pry'

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+require "bundler/setup"
+
+require "rails"
+require "redshift_connector"
+require "redshift_connector/logger"
+require "queuery_client"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/test/test_connector.rb
+++ b/test/test_connector.rb
@@ -23,4 +23,33 @@ class TestConnector < Test::Unit::TestCase
     )
     job.execute
   end
+
+  def test_enable_cast_transport_delta
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_delta(
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+
+      txn_id: data_date,
+      condition: %Q(data_date = date '#{data_date}'),
+      delete_cond: %Q(data_date = date '#{data_date}'),
+
+      columns: %w[id data_date item_id pv uu],
+      enable_cast: true
+    )
+    job.execute
+  end
+
+  def test_enable_cast_transport_all
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_all(
+      strategy: 'truncate',
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+      txn_id: data_date,
+      columns: %w[id data_date item_id pv uu],
+      enable_cast: true
+    )
+    job.execute
+  end
 end

--- a/test/test_direct_connector.rb
+++ b/test/test_direct_connector.rb
@@ -23,4 +23,33 @@ class TestConnector < Test::Unit::TestCase
     )
     job.execute
   end
+
+  def test_enable_transport_delta
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_delta(
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+
+      txn_id: data_date,
+      condition: %Q(data_date = date '#{data_date}'),
+      delete_cond: %Q(data_date = date '#{data_date}'),
+
+      columns: %w[id data_date item_id pv uu],
+      enable_cast: true
+    )
+    job.execute
+  end
+
+  def test_enable_transport_all
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_all(
+      strategy: 'truncate',
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+      txn_id: data_date,
+      columns: %w[id data_date item_id pv uu],
+      enable_cast: true
+    )
+    job.execute
+  end
 end


### PR DESCRIPTION
https://github.com/bricolages/redshift_connector/pull/24 で `RedshiftConnector#transport_all` / `RedshiftConnector#transport_delta` 用の型キャストオプションが追加されました。その挙動をテストするコードを追加します。
あとついでに開発環境下で動作チェックする時のGemfile&スクリプト追加もしておきます。（gem自体には入りません）